### PR TITLE
Fix #7: failed to active because missing dispose method

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -88,7 +88,9 @@ class ProviderManager
 
   registerProvider: (provider) ->
     return unless provider?
-    @providers.push(new ProviderMetadata(provider))
+    providerMetadata = new ProviderMetadata(provider)
+    @providers.push(providerMetadata)
+    return providerMetadata
 
   providersForScopeDescriptor: (scopeDescriptor) =>
     scopeChain = scopeChainForScopeDescriptor(scopeDescriptor)

--- a/lib/provider-metadata.coffee
+++ b/lib/provider-metadata.coffee
@@ -24,3 +24,5 @@ class ProviderMetadata
       selector.getSpecificity()
     else
       0
+
+  dispose: ->


### PR DESCRIPTION
The ProviderMetadata class is missing a dispose method for the CompositeDisposable array at `main.coffee:70`.
